### PR TITLE
Removes the leading space from the word confidentiality in two incidents

### DIFF
--- a/data/json/39CF36D5-7DCC-4823-BA14-33D584BE742B.json
+++ b/data/json/39CF36D5-7DCC-4823-BA14-33D584BE742B.json
@@ -27,7 +27,7 @@
     ]
   },
   "attribute": {
-    " confidentiality": {},
+    "confidentiality": {},
     "availability": {
       "variety": [
         "Loss"

--- a/data/json/ECBC8BE2-848C-4AD9-9721-003C9ABEFEFE.json
+++ b/data/json/ECBC8BE2-848C-4AD9-9721-003C9ABEFEFE.json
@@ -33,7 +33,7 @@
     ]
   },
   "attribute": {
-    " confidentiality": {},
+    "confidentiality": {},
     "availability": {
       "variety": [
         "Loss"


### PR DESCRIPTION
Not sure how it got in there to begin with. Looks like it might be auto-generated code.
