### PR TITLE
Addresses issue 19304; needs validation

### DIFF
--- a/data/json/submitted/cc2bd9d8-319d-41dc-98c6-c190c6f72875.JSON
+++ b/data/json/submitted/cc2bd9d8-319d-41dc-98c6-c190c6f72875.JSON
@@ -1,0 +1,155 @@
+{
+    "source_id": "vcdb",
+    "incident_id": "c99649d0-d197-11ed-8668-41a3926095b9",
+    "summary": "Hacker released a sample 5 million stolen records on a well-known hacking forum, claiming to have a 60GB stash of stolen data from music-streaming service Deezer, including 228 million email addresses.",
+    "security_incident": "Confirmed",
+    "reference": "https://grahamcluley.com/data-of-over-200-million-deezer-users-stolen-leaks-on-hacking-forum/",
+    "plus": {
+        "master_id": "cc2bd9d8-319d-41dc-98c6-c190c6f72875",
+        "modified": "2023-04-03T01:54:49.790Z",
+        "created": "2023-04-03T00:48:57.069Z",
+        "sub_source": "priority",
+        "attack_difficulty_initial": "Unknown",
+        "attack_difficulty_subsequent": "Unknown",
+        "security_maturity": "Unknown",
+        "analysis_status": "Needs review",
+        "analyst": "jaybobo",
+        "dbir_year": 2023,
+        "github": "19304"
+    },
+    "timeline": {
+        "incident": {
+            "year": 2019,
+            "month": 4,
+            "day": 22
+        },
+        "compromise": {
+            "unit": "Unknown"
+        },
+        "exfiltration": {
+            "unit": "Unknown"
+        },
+        "discovery": {
+            "value": 7,
+            "unit": "Months"
+        },
+        "containment": {
+            "unit": "NA"
+        }
+    },
+    "victim": {
+        "country": [
+            "FR"
+        ],
+        "region": [
+            "150155"
+        ],
+        "industry": "516210",
+        "employee_count": "Unknown"
+    },
+    "action": {
+        "hacking": {
+            "variety": [
+                "Unknown"
+            ],
+            "vector": [
+                "Partner"
+            ]
+        }
+    },
+    "actor": {
+        "external": {
+            "variety": [
+                "Unaffiliated"
+            ],
+            "motive": [
+                "Financial"
+            ],
+            "region": [
+                "000000"
+            ],
+            "notes": "Actor obtained data and posted it for sale to forum"
+        }
+    },
+    "asset": {
+        "assets": [
+            {
+                "variety": "P - End-user",
+                "amount": 228000000
+            }
+        ],
+        "cloud": [
+            "Unknown"
+        ],
+        "total_amount": 258000000
+    },
+    "attribute": {
+        "confidentiality": {
+            "data": [
+                {
+                    "variety": "Personal",
+                    "amount": 228000000
+                }
+            ],
+            "data_victim": [
+                "Customer"
+            ],
+            "state": [
+                "Unknown"
+            ],
+            "data_disclosure": "Yes",
+            "data_total": 228000000
+        }
+    },
+    "targeted": "Unknown",
+    "discovery_method": {
+        "external": {
+            "variety": [
+                "Actor disclosure"
+            ]
+        }
+    },
+    "value_chain": {
+        "development": {
+            "variety": [
+                "Unknown"
+            ]
+        },
+        "non-distribution services": {
+            "variety": [
+                "Marketplace"
+            ]
+        },
+        "targeting": {
+            "variety": [
+                "Unknown"
+            ]
+        },
+        "distribution": {
+            "variety": [
+                "Unknown"
+            ]
+        },
+        "cash-out": {
+            "variety": [
+                "Sell stolen goods"
+            ]
+        },
+        "money laundering": {
+            "variety": [
+                "Unknown"
+            ]
+        }
+    },
+    "impact": {
+        "loss": [
+            {
+                "variety": "Other"
+            }
+        ],
+        "overall_rating": "Unknown"
+    },
+    "schema_name": "vcdb",
+    "schema_version": "1.3.4",
+    "discovery_notes": "Actor posted data for sale on hacker forum"
+}


### PR DESCRIPTION
Addresses #19304 

@swidup before we increase volume, I want to make sure we're doing things correctly so there's only one record here.

1. I'd prefer to eventually just submit our issues already coded as json so that no one has to code them up. I  understand this could cause issues with assignment and duplication, but let me know what works best for you and we'll do our best to make it happen.

2. Depending on the regulator, we sometimes only have a handful of fields such as company name, number of citizens impacted and date of breach. It varies widely by organization (ex. OCC federal vs Maine OAG). If you'd prefer we only import those regulators where there are plentiful fields, we can do that as well.

